### PR TITLE
Clear queue in commit, so we don't repeat old queue items.  Allow safely...

### DIFF
--- a/lib/redic/pool.rb
+++ b/lib/redic/pool.rb
@@ -27,9 +27,10 @@ class Redic::Pool
 
   def commit
     @pool.with do |client|
-      Thread.current[@id].each do |args|
+      (Thread.current[@id] || []).each do |args|
         client.queue(*args)
       end
+      Thread.current[@id] = [] # clear the thread queue
 
       client.commit
     end


### PR DESCRIPTION
... calling commit before queue.
