### PR TITLE
Fixes redic-pool incompatabilty with latest ohm version (2.3.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.gs
+/Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+rmv:
+  - 2.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
-rmv:
+rvm:
   - 2.2.1

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "connection_pool"
+
 group :test do
   gem "rake"
   gem "cutest"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :test do
+  gem "rake"
+  gem "cutest"
+  gem "ohm"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "connection_pool"
-
 group :test do
   gem "rake"
   gem "cutest"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-group :test do
-  gem "rake"
-  gem "cutest"
-  gem "ohm"
-end

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Usage
 
     Array.new(100) do
       Thread.new do
-        $redis.call("GET", "foo")
+        $redis.call!("GET", "foo")
       end
     end.each(&:join)
 
-    $redis.call("INFO", "clients")[/connected_clients:(\d+)/, 1]
+    $redis.call!("INFO", "clients")[/connected_clients:(\d+)/, 1]
     # => "10"
 
 With Ohm

--- a/lib/redic/pool.rb
+++ b/lib/redic/pool.rb
@@ -2,8 +2,6 @@ require "connection_pool"
 require "redic"
 
 class Redic::Pool
-  VERSION = "1.0.1"
-
   attr :url
   attr :pool
 

--- a/lib/redic/pool.rb
+++ b/lib/redic/pool.rb
@@ -19,6 +19,7 @@ class Redic::Pool
       client.call(*args)
     end
   end
+  alias_method :call!, :call
 
   def queue(*args)
     Thread.current[@id] || (Thread.current[@id] = [])

--- a/lib/redic/version.rb
+++ b/lib/redic/version.rb
@@ -1,0 +1,6 @@
+module Redic
+  class Pool
+    # Current gem version
+    VERSION = "1.0.1"
+  end
+end

--- a/lib/redic/version.rb
+++ b/lib/redic/version.rb
@@ -1,4 +1,4 @@
-module Redic
+class Redic
   class Pool
     # Current gem version
     VERSION = "1.0.1"

--- a/redic-pool.gemspec
+++ b/redic-pool.gemspec
@@ -1,4 +1,4 @@
-require "./lib/redic/pool"
+require "./lib/redic/version"
 
 Gem::Specification.new do |s|
   s.name = "redic-pool"

--- a/redic-pool.gemspec
+++ b/redic-pool.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_dependency("connection_pool")
   s.add_dependency("redic")
 
   s.add_development_dependency("cutest")

--- a/redic-pool.gemspec
+++ b/redic-pool.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_dependency("redic")
-
-  s.add_development_dependency("cutest")
 end

--- a/redic-pool.gemspec
+++ b/redic-pool.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_dependency("redic", "~> 1.5.0")
-  s.add_dependency("connection_pool", "~> 2.2.0")
+  s.add_runtime_dependency 'redic', '~> 1.5', '>= 1.5.0'
+  s.add_runtime_dependency 'connection_pool', '~> 2.2', '>= 2.2.0'
 
-  s.add_development_dependency("rake", "~> 10.4.2")
-  s.add_development_dependency("cutest", "~> 1.2.2")
-  s.add_development_dependency("ohm", "~> 2.3.0")
+  s.add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'
+  s.add_development_dependency 'cutest', '~> 1.2', '>= 1.2.2'
+  s.add_development_dependency 'ohm', '~> 2.3', '>= 2.3.0'
 end

--- a/redic-pool.gemspec
+++ b/redic-pool.gemspec
@@ -2,6 +2,7 @@ require "./lib/redic/pool"
 
 Gem::Specification.new do |s|
   s.name = "redic-pool"
+  s.description = "A Redis connection pool using Redic"
 
   s.version = Redic::Pool::VERSION
 

--- a/redic-pool.gemspec
+++ b/redic-pool.gemspec
@@ -19,5 +19,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_dependency("redic")
+  s.add_dependency("redic", "~> 1.5.0")
+  s.add_dependency("connection_pool", "~> 2.2.0")
+
+  s.add_development_dependency("rake", "~> 10.4.2")
+  s.add_development_dependency("cutest", "~> 1.2.2")
+  s.add_development_dependency("ohm", "~> 2.3.0")
 end

--- a/test/ohm_test.rb
+++ b/test/ohm_test.rb
@@ -26,7 +26,7 @@ test "Pool - basic" do
 
   threads.each(&:join)
 
-  clients = Parsers.info(Ohm.redis.call("INFO", "clients")).fetch("connected_clients")
+  clients = Parsers.info(Ohm.redis.call!("INFO", "clients")).fetch("connected_clients")
 
   assert_equal(clients, "10")
 
@@ -45,7 +45,7 @@ test "Pool - basic" do
 
   threads.each(&:join)
 
-  clients = Parsers.info(Ohm.redis.call("INFO", "clients")).fetch("connected_clients")
+  clients = Parsers.info(Ohm.redis.call!("INFO", "clients")).fetch("connected_clients")
 
   assert_equal(clients, "10")
 end

--- a/test/pool_test.rb
+++ b/test/pool_test.rb
@@ -8,14 +8,14 @@ test "Pool" do |r|
   threads = Array.new(100) do
     Thread.new do
       10.times do
-        r.call("GET", "foo")
+        r.call!("GET", "foo")
       end
     end
   end
 
   threads.each(&:join)
 
-  clients = Parsers.info(r.call("INFO", "clients")).fetch("connected_clients")
+  clients = Parsers.info(r.call!("INFO", "clients")).fetch("connected_clients")
 
   assert_equal(clients, "10")
 
@@ -23,9 +23,9 @@ test "Pool" do |r|
 end
 
 test "MULTI return value with WATCH" do |r|
-  r.call("DEL", "foo")
+  r.call!("DEL", "foo")
 
-  r.call("WATCH", "foo", "bar")
+  r.call!("WATCH", "foo", "bar")
 
   r.queue("MULTI")
   r.queue("SET", "foo", "bar")
@@ -33,17 +33,17 @@ test "MULTI return value with WATCH" do |r|
 
   assert_equal(r.commit.last, ["OK"])
 
-  assert_equal(r.call("GET", "foo"), "bar")
+  assert_equal(r.call!("GET", "foo"), "bar")
 
   teardown(r)
 end
 
 test "Pipelining" do |r|
-  r.call("DEL", "foo")
+  r.call!("DEL", "foo")
 
   r.queue("SET", "foo", "bar")
 
-  assert_equal nil, r.call("GET", "foo")
+  assert_equal nil, r.call!("GET", "foo")
 
   teardown(r)
 end
@@ -52,9 +52,9 @@ test "Pipelining contention" do |r|
   threads = Array.new(100) do
     Thread.new do
       10.times do
-        r.call("SET", "foo", "bar")
+        r.call!("SET", "foo", "bar")
 
-        r.call("DEL", "foo")
+        r.call!("DEL", "foo")
       end
     end
   end
@@ -71,10 +71,10 @@ test "Pipelining contention" do |r|
 
   threads.each(&:join)
 
-  clients = Parsers.info(r.call("INFO", "clients")).fetch("connected_clients")
+  clients = Parsers.info(r.call!("INFO", "clients")).fetch("connected_clients")
 
   assert_equal(clients, "10")
-  assert_equal(r.call("GET", "foo"), nil)
+  assert_equal(r.call!("GET", "foo"), nil)
 
   teardown(r)
 end

--- a/test/prelude.rb
+++ b/test/prelude.rb
@@ -23,5 +23,5 @@ $redis = spawn("redis-server --dir /tmp --dbfilename '' --port 9999 --logfile /d
 sleep(0.5)
 
 def teardown(r)
-  r.pool.shutdown { |c| c.call("QUIT") }
+  r.pool.shutdown { |c| c.call!("QUIT") }
 end


### PR DESCRIPTION
1. The latest ohm version (2.3.0) uses the new redic API which includes a method `Redic#call!` (bang method). In order to conform to that new expected API this method was also added to `Redic::Pool` in this PR. After this PR is merged it should be possible to use redic-pool with ohm 2.3.0.
2. Travis support was added. Some additional commits were necessary in order to make travis bundle and build successfully.
3. The gemspec file now specifies gem dependency versions explicitly, which should be good practice. (Though, I am not totally sure if I am too strict here or which exact versions should be specified. Maybe you can help @djanowski )
